### PR TITLE
Upgrades this plugin to support Opensearch 2.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ NOTE: OpenSearch plugins much match _exactly_ in major.minor.path version to the
 
 | OpenSearch |      Plugin |  Release date |
 |-----------:|------------:|--------------:|
+|      2.10.0|     2.10.0.0|  Sep 25, 2023 |
 |      2.9.0 |     2.9.0.0 |  Aug 01, 2023 |
 |      2.8.0 |     2.8.0.0 |  Jun 13, 2023 |
 |      2.7.0 |     2.7.0.0 |  May 10, 2023 |
@@ -87,7 +88,7 @@ You need to install the plugin on every OpenSearch node that will be scraped by 
 
 To **install** the plugin:
 
-`./bin/opensearch-plugin install https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/releases/download/2.9.0.0/prometheus-exporter-2.9.0.0.zip`
+`./bin/opensearch-plugin install https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/releases/download/2.10.0.0/prometheus-exporter-2.10.0.0.zip`
 
 To **remove** the plugin.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #group = org.opensearch.plugin.prometheus
 
-version = 2.9.0.0
+version = 2.10.0.0
 
 pluginName = prometheus-exporter
 pluginClassname = org.opensearch.plugin.prometheus.PrometheusExporterPlugin


### PR DESCRIPTION
Upgrades this plugin to support Opensearch 2.10.0

[Opensearch 2.10.0 Release Notes](https://github.com/opensearch-project/opensearch-build/blob/main/release-notes/opensearch-release-notes-2.10.0.md)

## Description

Upgrades this plugin to support Opensearch 2.10.0

---

- [ ] All my commits include DCO.<br>_DCO stands for **Developer Certificate of Origin** and it is your declaration that your contribution is correctly attributed and licensed. Please read more about how to attach DCO to your commits [here](https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) (spoiler alert: in most cases it is as simple as using `-s` option when doing `git commit`).<br>Please be aware that commits without DCO will cause failure of PR CI workflow and can not be merged._
